### PR TITLE
prevent iterateParallel callback from being called multiple times in cas...

### DIFF
--- a/IIIAsync/IIIAsync.m
+++ b/IIIAsync/IIIAsync.m
@@ -132,6 +132,7 @@
 				
 				if(error){
 					dispatch_async(dispatchQueue, ^{
+						finish = YES;
 						callback(nil, error);
 					});
 					return;


### PR DESCRIPTION
...e of multiple errors.

Not sure if you intended for the callback to be called multiple times if multiple errors occur.... please discuss.
