### PR TITLE
FIXED - iterateParallel failure race condition

### DIFF
--- a/IIIAsync/IIIAsync.m
+++ b/IIIAsync/IIIAsync.m
@@ -136,8 +136,8 @@
 				if(finish) return;
 				
 				if(error){
+                    finish = YES;
 					dispatch_async(dispatchQueue, ^{
-						finish = YES;
 						callback(nil, error);
 					});
 					return;


### PR DESCRIPTION
Fixed iterateParallel method ; failure could lead to a race condition where the completionHandler was called multiple times

**Note that it seems that the indentation of the file seems to be a bit messed for the master repo leading to a more difficult to read diff**
*==> We should consider normalizing the repo's to space only indentation*