### PR TITLE
Terminate iterateSerially on first error

### DIFF
--- a/IIIAsync/IIIAsync.m
+++ b/IIIAsync/IIIAsync.m
@@ -99,6 +99,7 @@
 			iterator(object, index, ^(id result, NSError *error){
 				if(error){
 					callback(nil, error);
+					return;
 				}
 				
 				if(result){


### PR DESCRIPTION
(Apologies for the incorrect commit message, it references iterateParallel when it should reference iterateSerially.)

The behavior of iterateParallel is to terminate the loop if any of the tasks return an error. This makes sense and it matches the behavior of async.js. However, there is no `return;` statement in the error handler for iterateSerially which causes the loop to continue and fire the callback again at the end with no NSError set. This PR adds in the early termination for iterateSerially's error handler.